### PR TITLE
指向头像时弹出的浮层中，用户加入的月份有误

### DIFF
--- a/js/v2ex.ext.js
+++ b/js/v2ex.ext.js
@@ -93,7 +93,7 @@ var utils = (function () {
     formatDate: function (timestamp) {
       try {
         var t = new Date(timestamp * 1000);
-        return t.getFullYear() + '-' + t.getMonth() + '-' + t.getDate()
+        return t.getFullYear() + '-' + t.getMonth() + 1 + '-' + t.getDate()
           + ' ' + t.getHours() + ':' + t.getMinutes() + ':' + t.getSeconds();
       } catch (e) {
         return '';


### PR DESCRIPTION
比如：

![image](https://cloud.githubusercontent.com/assets/1173899/4823316/df5e7ac8-5f4d-11e4-8e75-839ed9f59069.png)
留意加入月份为 5 月，但是实际上是 6 月。

http://www.v2ex.com/member/xgfan
![image](https://cloud.githubusercontent.com/assets/1173899/4823321/ec5dde62-5f4d-11e4-84ed-53b9ee8f370f.png)
